### PR TITLE
add docker-compose.yml for using Jekyll in development

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ safe: true
 exclude:
   - Gemfile
   - Gemfile.lock
+  - docker-compose.yml
+  - README.md
 source: .
 incremental: false
 highlighter: rouge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  jekyll:
+    image: jekyll/builder:pages
+    command: jekyll serve
+    container_name: jekyll
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - "80:4000"
+    networks:
+      - webnet
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+      restart_policy:
+        condition: never
+networks:
+  webnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,5 @@ services:
       - "80:4000"
     networks:
       - webnet
-    deploy:
-      resources:
-        limits:
-          memory: 500M
-      restart_policy:
-        condition: never
 networks:
   webnet:


### PR DESCRIPTION
`docker-compose up` will start the official Jekyll image with the `serve` command on port `80` on host.